### PR TITLE
Check if resource exists before creation

### DIFF
--- a/hetznerdns/api/client.go
+++ b/hetznerdns/api/client.go
@@ -226,6 +226,23 @@ func (c *Client) DeleteZone(id string) error {
 	return fmt.Errorf("Error deleting Zone. HTTP status %d unhandled", resp.StatusCode)
 }
 
+// ZoneExistsByName checks if a DNS zone with a given name exists
+func (c *Client) ZoneExistsByName(name string) (bool, error) {
+	resp, err := c.doGetRequest(fmt.Sprintf("https://dns.hetzner.com/api/v1/zones?name=%s", name))
+	if err != nil {
+		return false, fmt.Errorf("Error getting zone %s: %s", name, err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Error getting Zone. HTTP status %d unhandled", resp.StatusCode)
+}
+
 // GetZoneByName reads the current state of a DNS zone with a given name
 func (c *Client) GetZoneByName(name string) (*Zone, error) {
 	resp, err := c.doGetRequest(fmt.Sprintf("https://dns.hetzner.com/api/v1/zones?name=%s", name))
@@ -283,6 +300,24 @@ func (c *Client) CreateZone(opts CreateZoneOpts) (*Zone, error) {
 
 	return nil, fmt.Errorf("Error creating Zone. HTTP status %d unhandled", resp.StatusCode)
 }
+
+// RecordExistsByName checks if a DNS Record with a given name exists in a given zone
+func (c *Client) RecordExistsByName(zoneID string, name string) (bool, error) {
+	resp, err := c.doGetRequest(fmt.Sprintf("https://dns.hetzner.com/api/v1/records?zone_id=%s&name=%s", zoneID, name))
+	if err != nil {
+		return false, fmt.Errorf("Error getting record %s: %s", name, err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Error getting Record. HTTP status %d unhandled", resp.StatusCode)
+}
+
 
 // GetRecordByName reads the current state of a DNS Record with a given name and zone id
 func (c *Client) GetRecordByName(zoneID string, name string) (*Record, error) {

--- a/hetznerdns/data_source_zone.go
+++ b/hetznerdns/data_source_zone.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/germanbrew/terraform-provider-hetznerdns/hetznerdns/api"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/hetznerdns/resource_zone.go
+++ b/hetznerdns/resource_zone.go
@@ -2,12 +2,11 @@ package hetznerdns
 
 import (
 	"context"
+	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/germanbrew/terraform-provider-hetznerdns/hetznerdns/api"
-
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -47,6 +46,19 @@ func resourceZoneCreate(c context.Context, d *schema.ResourceData, m interface{}
 
 	if ttl, isOk := d.GetOk("ttl"); isOk {
 		opts.TTL = ttl.(int)
+	}
+
+	zoneExists, err := client.ZoneExistsByName(opts.Name)
+	if err != nil {
+		log.Printf("[ERROR] Checking if resource zone exists failed: %s", err)
+		d.SetId("")
+		return diag.FromErr(err)
+	}
+
+	if zoneExists {
+		errMsg := fmt.Sprintf("DNS zone with name %s already exists", opts.Name)
+		log.Printf("[ERROR] %s", errMsg)
+		return diag.Errorf(errMsg)
 	}
 
 	resp, err := client.CreateZone(opts)


### PR DESCRIPTION
If the specified DNS zone or record already exists, the provider will now throw an error to prevent getting stuck.

Related to https://github.com/timohirt/terraform-provider-hetznerdns/issues/52