### PR TITLE
Set minimum release age for packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
         "minimumReleaseAge": 1
     },
     {
-        "matchUpdateTypes": ["patch"],
+        "matchUpdateTypes": ["patch", "pin"],
         "minimumReleaseAge": 1,
         "automerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,20 @@
     "config:best-practices"
   ],
   "dependencyDashboardLabels": ["Kind/Dependency"],
-  "labels": ["Kind/Dependency"]
+  "labels": ["Kind/Dependency"],
+  "packageRules": [
+    {
+        "matchUpdateTypes": ["major"],
+        "minimumReleaseAge": 2
+    },
+    {
+        "matchUpdateTypes": ["minor"],
+        "minimumReleaseAge": 1
+    },
+    {
+        "matchUpdateTypes": ["patch"],
+        "minimumReleaseAge": 1,
+        "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Set a minimum release age for dependencies before they are considered stable/safe to merge.

Also for patch and pin versions, after the minimum wait time has passed, renovate will trigger an auto-merge. 

@jkroepke What do you think?