### PR TITLE
fix: remove stale resources from state

### DIFF
--- a/internal/api/primary_server.go
+++ b/internal/api/primary_server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -35,7 +36,7 @@ func (c *Client) GetPrimaryServer(ctx context.Context, id string) (*PrimaryServe
 
 	switch resp.StatusCode {
 	case http.StatusNotFound:
-		return nil, nil
+		return nil, errors.New("primary server not found")
 	case http.StatusOK:
 		var response *PrimaryServerResponse
 

--- a/internal/api/primary_server.go
+++ b/internal/api/primary_server.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -36,7 +35,7 @@ func (c *Client) GetPrimaryServer(ctx context.Context, id string) (*PrimaryServe
 
 	switch resp.StatusCode {
 	case http.StatusNotFound:
-		return nil, errors.New(fmt.Sprintf("primary server %s not found", id))
+		return nil, fmt.Errorf("primary server %s not found", id)
 	case http.StatusOK:
 		var response *PrimaryServerResponse
 

--- a/internal/provider/primary_server_resource.go
+++ b/internal/provider/primary_server_resource.go
@@ -235,7 +235,6 @@ func (r *primaryServerResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	if server == nil {
-		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("Primary server with id %s doesn't exist, removing it from state", state.ID))
 		resp.State.RemoveResource(ctx)
 
 		return

--- a/internal/provider/primary_server_resource.go
+++ b/internal/provider/primary_server_resource.go
@@ -228,7 +228,7 @@ func (r *primaryServerResource) Read(ctx context.Context, req resource.ReadReque
 
 		return nil
 	})
-	if err != nil {
+	if err != nil && fmt.Sprint(err) != fmt.Sprintf("primary server %s not found", state.ID.ValueString()) {
 		resp.Diagnostics.AddError("API Error", fmt.Sprintf("read primary server: %s", err))
 
 		return

--- a/internal/provider/primary_server_resource.go
+++ b/internal/provider/primary_server_resource.go
@@ -236,6 +236,7 @@ func (r *primaryServerResource) Read(ctx context.Context, req resource.ReadReque
 
 	if server == nil {
 		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("Primary server with id %s doesn't exist, removing it from state", state.ID))
+		resp.State.RemoveResource(ctx)
 
 		return
 	}

--- a/internal/provider/primary_server_resource_test.go
+++ b/internal/provider/primary_server_resource_test.go
@@ -192,14 +192,14 @@ func TestAccPrimaryServer_StalePrimaryServersResources(t *testing.T) {
 						t.Fatalf("Zone %s not found", aZoneName)
 					}
 
-					primaryServer, err := apiClient.GetPrimaryServer(ctx, zone.ID)
+					primaryServer, err := apiClient.GetPrimaryServers(ctx, zone.ID)
 					if err != nil {
 						t.Fatalf("Error while fetching primary server: %s", err)
 					} else if primaryServer == nil {
 						t.Fatalf("Primary server %s not found", zone.ID)
 					}
 
-					err = apiClient.DeletePrimaryServer(ctx, primaryServer.ID)
+					err = apiClient.DeletePrimaryServer(ctx, primaryServer[0].ID)
 					if err != nil {
 						t.Fatalf("Error while deleting primary server: %s", err)
 					}

--- a/internal/provider/primary_server_resource_test.go
+++ b/internal/provider/primary_server_resource_test.go
@@ -1,12 +1,17 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/germanbrew/terraform-provider-hetznerdns/internal/api"
+	"github.com/germanbrew/terraform-provider-hetznerdns/internal/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -112,6 +117,88 @@ func TestAccPrimaryServer_TwoPrimaryServersResources(t *testing.T) {
 					resource.TestCheckResourceAttrSet("hetznerdns_primary_server.ps1", "id"),
 					resource.TestCheckResourceAttrSet("hetznerdns_primary_server.ps2", "id"),
 				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccPrimaryServer_StalePrimaryServersResources(t *testing.T) {
+	aZoneName := acctest.RandString(10) + ".online"
+	aZoneTTL := 3600
+
+	psAddress := "1.1.0.0"
+	psPort := 53
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: strings.Join(
+					[]string{
+						testAccZoneResourceConfig("test", aZoneName, aZoneTTL),
+						testAccPrimaryServerResourceConfigCreate("test", psAddress, psPort),
+					}, "\n",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("hetznerdns_primary_server.test", "id"),
+					resource.TestCheckResourceAttr("hetznerdns_primary_server.test", "address", psAddress),
+					resource.TestCheckResourceAttr("hetznerdns_primary_server.test", "port", strconv.Itoa(psPort)),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "hetznerdns_primary_server.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: strings.Join(
+					[]string{
+						testAccZoneResourceConfig("test", aZoneName, aZoneTTL),
+						testAccPrimaryServerResourceConfigCreate("test", psAddress, psPort*2),
+					}, "\n",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hetznerdns_primary_server.test", "port", strconv.Itoa(psPort*2)),
+				),
+			},
+			// Remove primary server from Hetzner DNS and check if it will be recreated by Terraform
+			{
+				PreConfig: func() {
+					var (
+						data      hetznerDNSProviderModel
+						apiToken  string
+						apiClient *api.Client
+						err       error
+					)
+
+					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_API_TOKEN", "")
+					httpClient := logging.NewLoggingHTTPTransport(http.DefaultTransport)
+					apiClient, err = api.New("https://dns.hetzner.com", apiToken, httpClient)
+					if err != nil {
+						t.Fatalf("Error while creating API apiClient: %s", err)
+					}
+					zone, err := apiClient.GetZoneByName(context.Background(), aZoneName)
+					if err != nil {
+						t.Fatalf("Error while fetching zone: %s", err)
+					}
+					primaryServer, err := apiClient.GetPrimaryServer(context.Background(), zone.ID)
+					if err != nil {
+						t.Fatalf("Error while fetching primary server: %s", err)
+					}
+					err = apiClient.DeletePrimaryServer(context.Background(), primaryServer.ID)
+					if err != nil {
+						t.Fatalf("Error while deleting primary server: %s", err)
+					}
+				},
+				// Check if the record is recreated
+				//ExpectNonEmptyPlan: true,
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile("hetznerdns_primary_server.test will be created"),
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/primary_server_resource_test.go
+++ b/internal/provider/primary_server_resource_test.go
@@ -196,7 +196,7 @@ func TestAccPrimaryServer_StalePrimaryServersResources(t *testing.T) {
 					}
 				},
 				// Check if the record is recreated
-				//ExpectNonEmptyPlan: true,
+				// ExpectNonEmptyPlan: true,
 				RefreshState: true,
 				ExpectError:  regexp.MustCompile("hetznerdns_primary_server.test will be created"),
 			},

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -266,6 +266,7 @@ func (r *recordResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	if record == nil {
 		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("DNS record with id %s doesn't exist, removing it from state", state.ID))
+		resp.State.RemoveResource(ctx)
 
 		return
 	}

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -265,7 +265,6 @@ func (r *recordResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	if record == nil {
-		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("DNS record with id %s doesn't exist, removing it from state", state.ID))
 		resp.State.RemoveResource(ctx)
 
 		return

--- a/internal/provider/record_resource_test.go
+++ b/internal/provider/record_resource_test.go
@@ -295,6 +295,9 @@ func TestAccRecord_StaleResources(t *testing.T) {
 			// Remove record from Hetzner DNS and check if it will be recreated by Terraform
 			{
 				PreConfig: func() {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+
 					var (
 						data      hetznerDNSProviderModel
 						apiToken  string
@@ -308,15 +311,15 @@ func TestAccRecord_StaleResources(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Error while creating API apiClient: %s", err)
 					}
-					zone, err := apiClient.GetZoneByName(context.Background(), zoneName)
+					zone, err := apiClient.GetZoneByName(ctx, zoneName)
 					if err != nil {
 						t.Fatalf("Error while fetching zone: %s", err)
 					}
-					record, err := apiClient.GetRecordByName(context.Background(), zone.ID, aName)
+					record, err := apiClient.GetRecordByName(ctx, zone.ID, aName)
 					if err != nil {
 						t.Fatalf("Error while fetching record: %s", err)
 					}
-					err = apiClient.DeleteRecord(context.Background(), record.ID)
+					err = apiClient.DeleteRecord(ctx, record.ID)
 					if err != nil {
 						t.Fatalf("Error while deleting record: %s", err)
 					}

--- a/internal/provider/record_resource_test.go
+++ b/internal/provider/record_resource_test.go
@@ -322,7 +322,7 @@ func TestAccRecord_StaleResources(t *testing.T) {
 					}
 				},
 				// Check if the record is recreated
-				//ExpectNonEmptyPlan: true,
+				// ExpectNonEmptyPlan: true,
 				RefreshState: true,
 				ExpectError:  regexp.MustCompile("hetznerdns_record.record1 will be created"),
 			},

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -260,7 +260,6 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	if zone == nil {
-		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("DNS zone with id %s doesn't exist, removing it from state", state.ID))
 		resp.State.RemoveResource(ctx)
 
 		return

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -261,6 +261,7 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	if zone == nil {
 		resp.Diagnostics.AddWarning("Resource Not Found", fmt.Sprintf("DNS zone with id %s doesn't exist, removing it from state", state.ID))
+		resp.State.RemoveResource(ctx)
 
 		return
 	}

--- a/internal/provider/zone_resource_test.go
+++ b/internal/provider/zone_resource_test.go
@@ -149,6 +149,9 @@ func TestAccZone_StaleZone(t *testing.T) {
 			// Remove zone from Hetzner DNS and check if it will be recreated by Terraform
 			{
 				PreConfig: func() {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+
 					var (
 						data      hetznerDNSProviderModel
 						apiToken  string
@@ -162,11 +165,11 @@ func TestAccZone_StaleZone(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Error while creating API apiClient: %s", err)
 					}
-					zone, err := apiClient.GetZoneByName(context.Background(), aZoneName)
+					zone, err := apiClient.GetZoneByName(ctx, aZoneName)
 					if err != nil {
 						t.Fatalf("Error while fetching zone: %s", err)
 					}
-					err = apiClient.DeleteZone(context.Background(), zone.ID)
+					err = apiClient.DeleteZone(ctx, zone.ID)
 					if err != nil {
 						t.Fatalf("Error while deleting zone: %s", err)
 					}

--- a/internal/provider/zone_resource_test.go
+++ b/internal/provider/zone_resource_test.go
@@ -172,7 +172,7 @@ func TestAccZone_StaleZone(t *testing.T) {
 					}
 				},
 				// Check if the zone is recreated
-				//ExpectNonEmptyPlan: true,
+				// ExpectNonEmptyPlan: true,
 				RefreshState: true,
 				ExpectError:  regexp.MustCompile("hetznerdns_zone.test will be created"),
 			},

--- a/internal/provider/zone_resource_test.go
+++ b/internal/provider/zone_resource_test.go
@@ -1,11 +1,16 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"testing"
 
+	"github.com/germanbrew/terraform-provider-hetznerdns/internal/api"
+	"github.com/germanbrew/terraform-provider-hetznerdns/internal/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -111,6 +116,65 @@ func TestAccZone_ZoneExists(t *testing.T) {
 			{
 				Config:      testAccZoneResourceConfig("test2", aZoneName, aZoneTTL),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("zone %q already exists", aZoneName)),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccZone_StaleZone(t *testing.T) {
+	aZoneName := acctest.RandString(10) + ".online"
+	aZoneTTL := 60
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccZoneResourceConfig("test", aZoneName, aZoneTTL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("hetznerdns_zone.test", "id"),
+					resource.TestCheckResourceAttr("hetznerdns_zone.test", "name", aZoneName),
+					resource.TestCheckResourceAttr("hetznerdns_zone.test", "ttl", strconv.Itoa(aZoneTTL)),
+					resource.TestCheckResourceAttrSet("hetznerdns_zone.test", "ns.#"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "hetznerdns_zone.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Remove zone from Hetzner DNS and check if it will be recreated by Terraform
+			{
+				PreConfig: func() {
+					var (
+						data      hetznerDNSProviderModel
+						apiToken  string
+						apiClient *api.Client
+						err       error
+					)
+
+					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_API_TOKEN", "")
+					httpClient := logging.NewLoggingHTTPTransport(http.DefaultTransport)
+					apiClient, err = api.New("https://dns.hetzner.com", apiToken, httpClient)
+					if err != nil {
+						t.Fatalf("Error while creating API apiClient: %s", err)
+					}
+					zone, err := apiClient.GetZoneByName(context.Background(), aZoneName)
+					if err != nil {
+						t.Fatalf("Error while fetching zone: %s", err)
+					}
+					err = apiClient.DeleteZone(context.Background(), zone.ID)
+					if err != nil {
+						t.Fatalf("Error while deleting zone: %s", err)
+					}
+				},
+				// Check if the zone is recreated
+				//ExpectNonEmptyPlan: true,
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile("hetznerdns_zone.test will be created"),
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
Stale resources will now get deleted from the state on `Read` execution instead of showing a `Warning: Resource Not Found`

