### PR TITLE
docs: remove backslash from timeout schemas

### DIFF
--- a/docs/data-sources/records.md
+++ b/docs/data-sources/records.md
@@ -33,7 +33,7 @@ Provides details about all Records of a Hetzner DNS Zone
 Optional:
 
 - `read` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 
 

--- a/docs/data-sources/zone.md
+++ b/docs/data-sources/zone.md
@@ -41,5 +41,5 @@ data "hetznerdns_zone" "zone1" {
 Optional:
 
 - `read` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m

--- a/docs/resources/primary_server.md
+++ b/docs/resources/primary_server.md
@@ -48,16 +48,16 @@ resource "hetznerdns_primary_server" "ps1" {
 Optional:
 
 - `create` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `delete` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `read` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `update` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 
 ## Import

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -96,16 +96,16 @@ resource "hetznerdns_record" "example_com_srv" {
 Optional:
 
 - `create` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `delete` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `read` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `update` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 
 ## Import

--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -42,16 +42,16 @@ resource "hetznerdns_zone" "zone1" {
 Optional:
 
 - `create` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `delete` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `read` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 - `update` (String) [Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m
 
 ## Import

--- a/internal/provider/primary_server_resource.go
+++ b/internal/provider/primary_server_resource.go
@@ -97,16 +97,16 @@ func (r *primaryServerResource) Schema(ctx context.Context, _ resource.SchemaReq
 				Delete: true,
 
 				CreateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				DeleteDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				ReadDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				UpdateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 			}),
 		},

--- a/internal/provider/record_resource.go
+++ b/internal/provider/record_resource.go
@@ -117,16 +117,16 @@ func (r *recordResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 				Delete: true,
 
 				CreateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				DeleteDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				ReadDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				UpdateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 			}),
 		},

--- a/internal/provider/records_data_source.go
+++ b/internal/provider/records_data_source.go
@@ -102,7 +102,7 @@ func (d *recordsDataSource) Schema(ctx context.Context, _ datasource.SchemaReque
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.BlockWithOpts(ctx, timeouts.Opts{
 				ReadDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 			}),
 		},

--- a/internal/provider/zone_data_source.go
+++ b/internal/provider/zone_data_source.go
@@ -72,7 +72,7 @@ func (d *zoneDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest,
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.BlockWithOpts(ctx, timeouts.Opts{
 				ReadDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 			}),
 		},

--- a/internal/provider/zone_resource.go
+++ b/internal/provider/zone_resource.go
@@ -107,16 +107,16 @@ func (r *zoneResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				Delete: true,
 
 				CreateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				DeleteDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				ReadDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 				UpdateDescription: `[Operation Timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) consisting of
-numbers and unit suffixes, such as "30s" or "2h45m".\
+numbers and unit suffixes, such as "30s" or "2h45m".
 Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Default: 5m`,
 			}),
 		},


### PR DESCRIPTION
Removes the backslash from docs: `...such as "30s" or "2h45m".\ Valid time units are...`