### PR TITLE
feat: rename API token environment variable 

### DIFF
--- a/.github/workflows/cleanup_zones.yaml
+++ b/.github/workflows/cleanup_zones.yaml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - name: Cleanup DNS Zones
         env:
-          HETZNER_DNS_API_TOKEN: ${{ secrets.HETZNER_DNS_API_TOKEN }}
+          HETZNER_DNS_TOKEN: ${{ secrets.HETZNER_DNS_API_TOKEN }}
         run: |
-          curl "https://dns.hetzner.com/api/v1/zones" -H "Auth-Api-Token: ${HETZNER_DNS_API_TOKEN}" -s | jq -r '.zones[] | .id' | xargs -I {} curl -XDELETE "https://dns.hetzner.com/api/v1/zones/{}" -H "Auth-Api-Token: ${HETZNER_DNS_API_TOKEN}"
+          curl "https://dns.hetzner.com/api/v1/zones" -H "Auth-Api-Token: ${HETZNER_DNS_TOKEN}" -s | jq -r '.zones[] | .id' | xargs -I {} curl -XDELETE "https://dns.hetzner.com/api/v1/zones/{}" -H "Auth-Api-Token: ${HETZNER_DNS_TOKEN}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,6 +91,6 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
-          HETZNER_DNS_API_TOKEN: ${{ secrets.HETZNER_DNS_API_TOKEN }}
+          HETZNER_DNS_TOKEN: ${{ secrets.HETZNER_DNS_API_TOKEN }}
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ You don't have to enter the API token anymore.
 
 ### Inject the API Token via the Environment
 
-Assign the API token to `HETZNER_DNS_API_TOKEN` env variable.
+Assign the API token to `HETZNER_DNS_TOKEN` env variable.
 
 ```sh
-export HETZNER_DNS_API_TOKEN=<your api token>
+export HETZNER_DNS_TOKEN=<your api token>
 ```
 
 The provider uses this token, and you don't have to enter it anymore.

--- a/docs/guides/migration-from-timohirt-hetznerdns.md
+++ b/docs/guides/migration-from-timohirt-hetznerdns.md
@@ -25,7 +25,7 @@ If you previously used the `timohirt/hetznerdns` provider, you can easily replac
     }
     ```
 
-2. If you have `apitoken` defined inside you provider config, replace it with `api_token`. The environment variable `HETZNER_DNS_API_TOKEN` has not changed.
+2. If you have `apitoken` defined inside you provider config, replace it with `api_token`. The environment variable is now called `HETZNER_DNS_TOKEN` instead of `HETZNER_DNS_API_TOKEN`.
    Also see our [Docs Overview](https://registry.terraform.io/providers/germanbrew/hetznerdns/latest/docs#schema), as we have more configuration options for you to choose.
 
     ```diff

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,6 @@ resource "hetznerdns_record" "web" {
 
 ### Optional
 
-- `api_token` (String, Sensitive) The Hetzner DNS API token. You can pass it using the env variable `HETZNER_DNS_API_TOKEN` as well.
+- `api_token` (String, Sensitive) The Hetzner DNS API token. You can pass it using the env variable `HETZNER_DNS_TOKEN` as well. The old env variable `HETZNER_DNS_API_TOKEN` is now deprecated and will be removed in a future release.
 - `enable_txt_formatter` (Boolean) `Default: true` Toggles the automatic formatter for TXT record values. Values greater than 255 bytes get split into multiple quoted chunks ([RFC4408](https://datatracker.ietf.org/doc/html/rfc4408#section-3.1.3)). You can pass it using the env variable `HETZNER_DNS_ENABLE_TXT_FORMATTER` as well.
 - `max_retries` (Number) `Default: 1` The maximum number of retries to perform when an API request fails. You can pass it using the env variable `HETZNER_DNS_MAX_RETRIES` as well.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,6 @@ resource "hetznerdns_record" "web" {
 
 ### Optional
 
-- `api_token` (String, Sensitive) The Hetzner DNS API token. You can pass it using the env variable `HETZNER_DNS_TOKEN` as well. The old env variable `HETZNER_DNS_API_TOKEN` is now deprecated and will be removed in a future release.
+- `api_token` (String, Sensitive) The Hetzner DNS API token. You can pass it using the env variable `HETZNER_DNS_TOKEN` as well. The old env variable `HETZNER_DNS_API_TOKEN` is deprecated and will be removed in a future release.
 - `enable_txt_formatter` (Boolean) `Default: true` Toggles the automatic formatter for TXT record values. Values greater than 255 bytes get split into multiple quoted chunks ([RFC4408](https://datatracker.ietf.org/doc/html/rfc4408#section-3.1.3)). You can pass it using the env variable `HETZNER_DNS_ENABLE_TXT_FORMATTER` as well.
 - `max_retries` (Number) `Default: 1` The maximum number of retries to perform when an API request fails. You can pass it using the env variable `HETZNER_DNS_MAX_RETRIES` as well.

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -117,7 +117,7 @@ Import is supported using the following syntax:
 # a zone and then copy the id.
 #
 # curl "https://dns.hetzner.com/api/v1/records" \
-#      -H "Auth-API-Token: $HETZNER_DNS_API_TOKEN" | jq .
+#      -H "Auth-API-Token: $HETZNER_DNS_TOKEN" | jq .
 #
 # {
 #   "records": [

--- a/examples/resources/hetznerdns_record/import.sh
+++ b/examples/resources/hetznerdns_record/import.sh
@@ -2,7 +2,7 @@
 # a zone and then copy the id.
 #
 # curl "https://dns.hetzner.com/api/v1/records" \
-#      -H "Auth-API-Token: $HETZNER_DNS_API_TOKEN" | jq .
+#      -H "Auth-API-Token: $HETZNER_DNS_TOKEN" | jq .
 #
 # {
 #   "records": [

--- a/internal/provider/primary_server_resource_test.go
+++ b/internal/provider/primary_server_resource_test.go
@@ -205,7 +205,7 @@ func TestAccPrimaryServer_StalePrimaryServersResources(t *testing.T) {
 						err       error
 					)
 
-					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_API_TOKEN", "")
+					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_TOKEN", "")
 					httpClient := logging.NewLoggingHTTPTransport(http.DefaultTransport)
 					apiClient, err = api.New("https://dns.hetzner.com", apiToken, httpClient)
 					if err != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -19,7 +19,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("HETZNER_DNS_API_TOKEN"); v == "" {
-		t.Fatal("HETZNER_DNS_API_TOKEN must be set for acceptance tests")
+	if v := os.Getenv("HETZNER_DNS_TOKEN"); v == "" {
+		t.Fatal("HETZNER_DNS_TOKEN must be set for acceptance tests")
 	}
 }

--- a/internal/provider/zone_resource_test.go
+++ b/internal/provider/zone_resource_test.go
@@ -159,7 +159,7 @@ func TestAccZone_StaleZone(t *testing.T) {
 						err       error
 					)
 
-					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_API_TOKEN", "")
+					apiToken = utils.ConfigureStringAttribute(data.ApiToken, "HETZNER_DNS_TOKEN", "")
 					httpClient := logging.NewLoggingHTTPTransport(http.DefaultTransport)
 					apiClient, err = api.New("https://dns.hetzner.com", apiToken, httpClient)
 					if err != nil {

--- a/templates/guides/migration-from-timohirt-hetznerdns.md
+++ b/templates/guides/migration-from-timohirt-hetznerdns.md
@@ -25,7 +25,7 @@ If you previously used the `timohirt/hetznerdns` provider, you can easily replac
     }
     ```
 
-2. If you have `apitoken` defined inside you provider config, replace it with `api_token`. The environment variable `HETZNER_DNS_API_TOKEN` has not changed.
+2. If you have `apitoken` defined inside you provider config, replace it with `api_token`. The environment variable is now called `HETZNER_DNS_TOKEN` instead of `HETZNER_DNS_API_TOKEN`.
    Also see our [Docs Overview](https://registry.terraform.io/providers/germanbrew/hetznerdns/latest/docs#schema), as we have more configuration options for you to choose.
 
     ```diff


### PR DESCRIPTION
1. Renamed `HETZNER_DNS_API_TOKEN` environment variable to `HETZNER_DNS_TOKEN`
2. Added a test for the usage with deprecated token: `TestAccRecord_ResourcesWithDeprecatedApiToken`
3. Updated docs and added deprecation notice and warning log when running provider with the deprecated env var

```
╷
│ Warning: Deprecated API Token Environment Variable
│ 
│   with provider["registry.terraform.io/germanbrew/hetznerdns"],
│   on _provider.tf line 47, in provider "hetznerdns":
│   47: provider "hetznerdns" {
│ 
│ The environment variable `HETZNER_DNS_API_TOKEN` is deprecated and will be removed in a future release. Please use `HETZNER_DNS_TOKEN` instead.
╵
```