### PR TITLE
Update record.md: Deleting escaping

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -78,7 +78,7 @@ resource "hetznerdns_record" "example_com_srv" {
 
 - `name` (String) Name of the DNS record to create
 - `type` (String) Time to live of this record
-- `value` (String) The value of the record (eg. 192.168.1.1). For TXT records with quoted values, the quotes have to be escaped in Terraform  (eg. "v=spf1 include:\_spf.google.com ~all" is represented by  "\\"v=spf1 include:\_spf.google.com ~all\\"" in Terraform)
+- `value` (String) The value of the record (eg. `"192.168.1.1"`).
 - `zone_id` (String) ID of the DNS zone to create the record in.
 
 ### Optional


### PR DESCRIPTION
Cause it isn't true anymore, or is it? (If still required, you'd need to change the above example)